### PR TITLE
SME-demo: Don't use deprecated xl config option

### DIFF
--- a/SME-demo/README.md
+++ b/SME-demo/README.md
@@ -20,7 +20,7 @@ This project demonstrates the usecase of AMD Secure memory Encryption (SME) tech
 - Navigate to frontend driver:`linux/demo-sme/frontend`
 - Compile the frontend driver : `make`
 - You'll need to embed `frontend_pv.ko` in your initramfs/bzImage.
-- Start the domU: `xl create -c hvm_guest.cfg`. Example of config can be found in this directory.
+- Start the domU: `xl create -c pvh_guest.cfg`. Example of config can be found in this directory.
 - Above command will take you to console of domU. Load frontend module: `insmod frontend_pv.ko`
 
 ### Usage:

--- a/SME-demo/pvh_guest.cfg
+++ b/SME-demo/pvh_guest.cfg
@@ -3,5 +3,5 @@ kernel="/path/to/bzImage"
 vcpus=2
 memory=4096
 name="linux-pvh-guest"
-builder = "hvm"
+type = "pvh"
 ramdisk = "/path/to/initramfs.img"


### PR DESCRIPTION
builder is a deprecated config option in `xl`. Let's not use it even in the example config for xl. Use `type=pvh` instead.
cc @olivierlambert 